### PR TITLE
incorrect checking for Null value

### DIFF
--- a/drivers/mfd/pcf50633-core.c
+++ b/drivers/mfd/pcf50633-core.c
@@ -248,18 +248,18 @@ static int pcf50633_probe(struct i2c_client *client,
 		pdev->dev.parent = pcf->dev;
 		ret = platform_device_add_data(pdev, &pdata->reg_init_data[i],
 					       sizeof(pdata->reg_init_data[i]));
-		if (ret)
+		if (!ret)
 			goto err;
 
 		ret = platform_device_add(pdev);
-		if (ret)
+		if (!ret)
 			goto err;
 
 		pcf->regulator_pdev[i] = pdev;
 	}
 
 	ret = sysfs_create_group(&client->dev.kobj, &pcf_attr_group);
-	if (ret)
+	if (!ret)
 		dev_warn(pcf->dev, "error creating sysfs entries\n");
 
 	if (pdata->probe_done)


### PR DESCRIPTION
in lines 251 255 262 the checking for null values was incorrect because the true state was considered as a false statement